### PR TITLE
fix: correct auth page title typo

### DIFF
--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -102,7 +102,7 @@ export default function AuthPage() {
           <div className="flex items-center justify-center">
             <Target className="h-12 w-12 text-primary" />
           </div>
-          <h1 className="text-3xl font-bold text-foreground">Week Yer</h1>
+          <h1 className="text-3xl font-bold text-foreground">Week Year</h1>
           <p className="text-muted-foreground">
             Seu sistema de produtividade de 12 semanas
           </p>


### PR DESCRIPTION
## Summary
- fix auth screen title spelling from "Week Yer" to "Week Year"

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: eslint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a47714a883228d4f54498336b9ed