### PR TITLE
feat: display completed tasks after pending ones

### DIFF
--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -102,7 +102,7 @@ export default function AuthPage() {
           <div className="flex items-center justify-center">
             <Target className="h-12 w-12 text-primary" />
           </div>
-          <h1 className="text-3xl font-bold text-foreground">Week Yer</h1>
+          <h1 className="text-3xl font-bold text-foreground">Week Year</h1>
           <p className="text-muted-foreground">
             Seu sistema de produtividade de 12 semanas
           </p>

--- a/src/pages/PlanningPage.tsx
+++ b/src/pages/PlanningPage.tsx
@@ -93,9 +93,12 @@ export default function PlanningPage() {
     return Math.min(Math.max(diffWeeks, 1), 12);
   }
 
-  // Sort actions by priority (high > medium > low)
-  const sortActionsByPriority = (actions: Action[]) => {
+  // Sort actions placing pending ones first, then by priority (high > medium > low)
+  const sortActions = (actions: Action[]) => {
     return actions.sort((a, b) => {
+      if (a.completed !== b.completed) {
+        return a.completed ? 1 : -1;
+      }
       const priorityOrder = { high: 3, medium: 2, low: 1 };
       return priorityOrder[b.priority] - priorityOrder[a.priority];
     });
@@ -107,7 +110,7 @@ export default function PlanningPage() {
     const actions = currentCycle.objectives.flatMap(obj => 
       obj.actions.filter(action => action.weekNumber === week)
     );
-    return sortActionsByPriority(actions);
+    return sortActions(actions);
   }
 
   if (!currentCycle) {
@@ -281,7 +284,7 @@ export default function PlanningPage() {
                 </CardHeader>
                 {weekActions.length > 0 && (
                   <CardContent className="space-y-3">
-                 {sortActionsByPriority(weekActions).map((action) => (
+                 {sortActions(weekActions).map((action) => (
                        <ActionCard
                         key={action.id}
                         action={action}
@@ -315,7 +318,7 @@ export default function PlanningPage() {
             </Card>
           ) : (
             currentCycle.objectives.map((objective) => {
-              const objectiveActions = sortActionsByPriority(objective.actions);
+              const objectiveActions = sortActions(objective.actions);
               const completedCount = objectiveActions.filter(a => a.completed).length;
               
               return (


### PR DESCRIPTION
## Summary
- fix auth screen title spelling from "Week Yer" to "Week Year"
- sort actions so incomplete tasks appear before completed ones in planning views

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 30 problems: 16 errors, 14 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a47714a883228d4f54498336b9ed