### PR TITLE
Centralize cycle state and await refetch after actions

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -3,14 +3,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Button } from "@/components/ui/button";
 import { Target, Calendar, TrendingUp, CheckCircle } from "lucide-react";
-import { useCurrentCycle } from "@/hooks/useSupabaseData";
+import { useCycles } from "@/hooks/useSupabaseData";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useGuide } from "@/components/guide/GuideProvider";
 import { getCurrentWeek } from "@/utils/getCurrentWeek";
 
 export function Dashboard() {
-  const { currentCycle, loading } = useCurrentCycle();
+  const { currentCycle, loading } = useCycles();
   const [weeklyScore, setWeeklyScore] = useState(0);
   const [overallProgress, setOverallProgress] = useState(0);
   const navigate = useNavigate();

--- a/src/components/guide/steps/ObjectivesStep.tsx
+++ b/src/components/guide/steps/ObjectivesStep.tsx
@@ -6,7 +6,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { Target, CheckCircle, Plus, Trash2 } from 'lucide-react';
 import { ValidationFeedback } from '../shared/ValidationFeedback';
-import { useCurrentCycle, useObjectives, useVisions, useCycles } from '@/hooks/useSupabaseData';
+import { useObjectives, useVisions, useCycles } from '@/hooks/useSupabaseData';
 import { useToast } from '@/hooks/use-toast';
 import { addDays } from 'date-fns';
 
@@ -29,8 +29,7 @@ export function ObjectivesStep({ onComplete }: ObjectivesStepProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   
   const { visions } = useVisions();
-  const { currentCycle } = useCurrentCycle();
-  const { cycles, addCycle } = useCycles();
+  const { currentCycle, cycles, addCycle } = useCycles();
   const { objectives: existingObjectives, addObjective } = useObjectives(currentCycle?.id);
   const { toast } = useToast();
 

--- a/src/hooks/useSupabaseData.ts
+++ b/src/hooks/useSupabaseData.ts
@@ -135,6 +135,7 @@ export const useCycles = () => {
   const { user } = useAuth();
   const [cycles, setCycles] = useState<Cycle[]>([]);
   const [loading, setLoading] = useState(true);
+  const [currentCycleId, setCurrentCycleId] = useState<string | null>(null);
 
   const fetchCycles = async () => {
     if (!user) return;
@@ -206,6 +207,14 @@ export const useCycles = () => {
     fetchCycles();
   }, [user]);
 
+  useEffect(() => {
+    if (cycles.length > 0) {
+      const activeCycle = cycles.find(c => c.status === 'active');
+      const currentId = activeCycle?.id || cycles[0]?.id || null;
+      setCurrentCycleId(currentId);
+    }
+  }, [cycles]);
+
   const addCycle = async (cycle: Omit<Cycle, 'id' | 'objectives' | 'weeklyReviews'>) => {
     if (!user) return;
     
@@ -275,26 +284,9 @@ export const useCycles = () => {
     }
   };
 
-  return { cycles, loading, addCycle, updateCycle, refetch: fetchCycles };
-};
-
-// Current cycle hook
-export const useCurrentCycle = () => {
-  const { cycles, loading } = useCycles();
-  const [currentCycleId, setCurrentCycleId] = useState<string | null>(null);
-
-  // Get active cycle or most recent one
-  useEffect(() => {
-    if (cycles.length > 0) {
-      const activeCycle = cycles.find(c => c.status === 'active');
-      const currentId = activeCycle?.id || cycles[0]?.id || null;
-      setCurrentCycleId(currentId);
-    }
-  }, [cycles]);
-
   const currentCycle = cycles.find(c => c.id === currentCycleId) || null;
 
-  return { currentCycle, currentCycleId, setCurrentCycleId, loading };
+  return { cycles, currentCycle, currentCycleId, setCurrentCycleId, loading, addCycle, updateCycle, refetch: fetchCycles };
 };
 
 // Objectives hooks

--- a/src/pages/ExecutionPage.tsx
+++ b/src/pages/ExecutionPage.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
-import { useCurrentCycle, useCycles } from "@/hooks/useSupabaseData";
+import { useCycles } from "@/hooks/useSupabaseData";
 import { Action } from "@/types";
 import { CheckCircle, Clock, AlertCircle } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
@@ -12,8 +12,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { getCurrentWeek } from "@/utils/getCurrentWeek";
 
 export default function ExecutionPage() {
-  const { currentCycle } = useCurrentCycle();
-  const { refetch: refetchCycles } = useCycles();
+  const { currentCycle, refetch: refetchCycles } = useCycles();
   const [currentWeek, setCurrentWeek] = useState(1);
   const [weeklyScore, setWeeklyScore] = useState(0);
   const [optimisticUpdates, setOptimisticUpdates] = useState<Record<string, boolean>>({});
@@ -78,7 +77,7 @@ export default function ExecutionPage() {
         return newUpdates;
       });
       
-      refetchCycles();
+      await refetchCycles();
 
       toast({
         title: completed ? "Ação concluída!" : "Ação desmarcada",

--- a/src/pages/ObjectivesPage.tsx
+++ b/src/pages/ObjectivesPage.tsx
@@ -6,13 +6,13 @@ import { Badge } from "@/components/ui/badge";
 import { Plus, Target, AlertTriangle } from "lucide-react";
 import { ObjectiveCard } from "@/components/ObjectiveCard";
 import { ObjectiveForm } from "@/components/ObjectiveForm";
-import { useCurrentCycle, useVisions, useObjectives } from "@/hooks/useSupabaseData";
+import { useVisions, useObjectives, useCycles } from "@/hooks/useSupabaseData";
 import { Objective } from "@/types";
 import { useToast } from "@/hooks/use-toast";
 
 export default function ObjectivesPage() {
   const { visions } = useVisions();
-  const { currentCycle, currentCycleId } = useCurrentCycle();
+  const { currentCycle, currentCycleId } = useCycles();
   const { objectives, addObjective, updateObjective, deleteObjective } = useObjectives(currentCycleId || undefined);
   const [showObjectiveForm, setShowObjectiveForm] = useState(false);
   const [editingObjective, setEditingObjective] = useState<Objective | undefined>();

--- a/src/pages/PlanningPage.tsx
+++ b/src/pages/PlanningPage.tsx
@@ -7,15 +7,14 @@ import { Plus, Calendar, Target, CheckCircle, AlertTriangle, Edit2 } from "lucid
 import { ActionCard } from "@/components/ActionCard";
 import { ActionForm } from "@/components/ActionForm";
 import { CycleForm } from "@/components/CycleForm";
-import { useCurrentCycle, useCycles, useActions } from "@/hooks/useSupabaseData";
+import { useCycles, useActions } from "@/hooks/useSupabaseData";
 import { Cycle, Action } from "@/types";
 import { useToast } from "@/hooks/use-toast";
 import { getCurrentWeek } from "@/utils/getCurrentWeek";
 import { useSearchParams } from "react-router-dom";
 
 export default function PlanningPage() {
-  const { cycles, addCycle, updateCycle, refetch: refetchCycles } = useCycles();
-  const { currentCycle, currentCycleId } = useCurrentCycle();
+  const { cycles, addCycle, updateCycle, refetch: refetchCycles, currentCycle, currentCycleId } = useCycles();
   const [selectedObjectiveId, setSelectedObjectiveId] = useState<string>("");
   const { actions: allActions, addAction, updateAction, deleteAction } = useActions(selectedObjectiveId || undefined);
   const [showActionForm, setShowActionForm] = useState(false);
@@ -62,7 +61,7 @@ export default function PlanningPage() {
     }
 
     await addAction(actionData);
-    refetchCycles();
+    await refetchCycles();
   };
 
   const handleEditAction = async (actionData: Omit<Action, 'id' | 'completed' | 'completedAt'>) => {
@@ -70,7 +69,7 @@ export default function PlanningPage() {
 
     await updateAction(editingAction.id, actionData);
     setEditingAction(undefined);
-    refetchCycles();
+    await refetchCycles();
   };
 
   const handleToggleAction = async (actionId: string) => {
@@ -78,12 +77,12 @@ export default function PlanningPage() {
     if (!action) return;
 
     await updateAction(actionId, { completed: !action.completed });
-    refetchCycles();
+    await refetchCycles();
   };
 
   const handleDeleteAction = async (actionId: string) => {
     await deleteAction(actionId);
-    refetchCycles();
+    await refetchCycles();
   };
 
   function getCurrentWeekNumber(cycle: Cycle | null): number {

--- a/src/pages/ReviewsPage.tsx
+++ b/src/pages/ReviewsPage.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Plus, Calendar, TrendingUp, BookOpen, AlertTriangle } from "lucide-react";
 import { WeeklyReviewForm } from "@/components/WeeklyReviewForm";
-import { useCurrentCycle, useCycles, useWeeklyReviews } from "@/hooks/useSupabaseData";
+import { useCycles, useWeeklyReviews } from "@/hooks/useSupabaseData";
 import { WeeklyReview } from "@/types";
 import { v4 as uuidv4 } from "uuid";
 import { useToast } from "@/hooks/use-toast";
@@ -13,7 +13,7 @@ import { format } from "date-fns";
 import { ptBR } from "date-fns/locale";
 
 export default function ReviewsPage() {
-  const { currentCycle, currentCycleId } = useCurrentCycle();
+  const { currentCycle, currentCycleId } = useCycles();
   const { reviews, addReview } = useWeeklyReviews(currentCycleId || undefined);
   const [showReviewForm, setShowReviewForm] = useState(false);
   const [selectedWeek, setSelectedWeek] = useState<number | null>(null);


### PR DESCRIPTION
## Summary
- manage current cycle inside `useCycles` and expose ID and refetch helpers
- consume unified cycles state across planning/execution pages
- await `refetchCycles` when actions change to reflect updates immediately

## Testing
- `npm test` *(fails: Cannot find module '/workspace/weeks-focus/src/utils/getCurrentWeek' imported from /workspace/weeks-focus/src/utils/getCurrentWeek.test.ts)*
- `npm run lint` *(fails: 16 errors, 14 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d488616083228d0689f63159089c